### PR TITLE
Rstudio3.6.0 bioc3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bioconductor/release_base2:R3.6.0_Bioc3.9
 
 LABEL maintainer="josephs@axioresearch.com" \
       description="RStudio docker image used at Axio Research" \
-      version="1.0"
+      version="2.0"
 
 RUN apt-get update -y && apt-get -y install git subversion python python3 python-pip python3-pip
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Axio_rstudio
 Custom rstudio container used at Axio Research
 
+__Bioconductor release_base2 image with R3.6.0 and BioC 3.9__
+___
 This is a custom rstudio container used by Axio Research. It contains ~Bioconductor packages as well as~ custom built Axio Research R packages.
 
 To run:


### PR DESCRIPTION
merging rstudio 3.6.0/bioc3.9 release with master as the 'latest' version